### PR TITLE
時間割データのfirebase連携が概ね完成した

### DIFF
--- a/frontend/src/component/TimeTable/TimeTableContext.tsx
+++ b/frontend/src/component/TimeTable/TimeTableContext.tsx
@@ -68,13 +68,12 @@ export const TimeTableProvider = ({ children }) => {
         0
       );
 
-      if (auth.currentUser.uid || userClassPeriodDatas.length === 0) {
+      if (auth.currentUser.uid) {
         try {
-          const refFiresrore = doc(
+          const classPeriodsDataRef = doc(
             db,
             `UserClassPeriodsData/${auth.currentUser.uid}`
           );
-          console.log("userClassPeriodsData", userClassPeriodDatas);
           // fireStoreはオブジェクトの中に一つでもundefinedのプロパティが存在したら保存できないから、undefinedの要素を消すための作業
           const newData = userClassPeriodDatas
             .map((el: ClassPeriod) => {
@@ -89,9 +88,8 @@ export const TimeTableProvider = ({ children }) => {
               return filteredData;
             })
             .filter((el) => Object.keys(el).length > 0);
-          console.log("newData", newData);
           await setDoc(
-            refFiresrore,
+            classPeriodsDataRef,
             {
               userId: auth.currentUser.uid,
               classPeriods: newData,


### PR DESCRIPTION
# 時間割データをfirebaseに保存する処理が大体完成した。
変更点は以下の通りである。
・timeTableContexに自分の時間割データが変更されるたびにfirestore内のUserClassPeriodsDataコレクション内にid=uuidのドキュメントを作成、更新するというメソッドを追加した

# 問題点
・時間割データが更新されるたびにwriteが走るため、ユーザーが増えるとリクエストがパンクする可能性が考えられる。

# 解決策
・型の継承を行なって、データの正規化をすれば最小リクエストで済む(正規化すれば、例えば、時間割データ内のコマの色を変えるみたいな頻繁に行われる変更時にはリクエストが走らなくて、登録授業を増やしたり消したりみたいな重要な変更の時だけリクエストが走る的な感じにできるからリクエストが最適化される)が、改修が必要になるため、やばくなったらでいいと思うけどどうですか？