### PR TITLE
フレンド登録用のトークンの発行タイミングを初回ログイン時のHomeViewの初回コンポーネントマウント時に変更

### DIFF
--- a/frontend/src/View/HomeView.tsx
+++ b/frontend/src/View/HomeView.tsx
@@ -16,6 +16,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 import HomeCarousel from "../component/Home/HomeViewCarousel.tsx";
+import * as Crypto from "expo-crypto";
 import Specialsite from "../component/Home/HomeViewSpecial";
 import { onAuthStateChanged } from "firebase/auth";
 import { auth } from "../../firebase";
@@ -26,7 +27,7 @@ import {
   setUserObject,
 } from "../redux/actions/userAction";
 import { useDispatch, useSelector } from "react-redux";
-import { doc, getDoc } from "@firebase/firestore";
+import { collection, doc, getDoc, setDoc } from "@firebase/firestore";
 import { ref, getDownloadURL } from "firebase/storage";
 import { storage, db } from "../../firebase";
 import {
@@ -41,7 +42,6 @@ import NewAppList from "../component/Home/NewAppList.tsx";
 import { Foundation } from "@expo/vector-icons";
 import { useTimeTable } from "../component/TimeTable/TimeTableContext";
 import { AsyncFunctions } from "../component/TimeTable/classObject/async-functions";
-import { onAppStart } from "../services/onAppStart";
 
 //右上アクションボタンのコンポーネント
 const Headerlist = (props) => {
@@ -175,14 +175,41 @@ const HomeView = (props) => {
     setUserIconImageUri,
   } = useTimeTable();
 
+  const user = useSelector((state: any) => state.user.userObject);
+
+  const firebaseUserAddFriendConvertToken = async (friendConvertToken) => {
+    try {
+      // Firestoreの "friends" コレクションにドキュメントを追加
+      await setDoc(
+        doc(collection(db, "users"), `${auth.currentUser.uid}`),
+        {
+          friendConvertToken: friendConvertToken,
+        },
+        { merge: true }
+      );
+      dispatch(
+        setUserObject({ ...user, friendConvertToken: friendConvertToken })
+      );
+    } catch (error) {
+      console.error("Error adding friend convert token: ", error);
+      throw error; // エラーハンドリング
+    }
+  };
+
+  const setFriendConvertToken = async () => {
+    if (!user.hasOwnProperty("friendConvertToken")) {
+      await firebaseUserAddFriendConvertToken(Crypto.randomUUID());
+    }
+  };
+
   useEffect(() => {
-    onAppStart();
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
         // ユーザーがログインしている場合
         dispatch(handleLoginAction(user.emailVerified));
         dispatch(setUserUUIDAction(user.uid));
         await fetchFirebaseNotificationData();
+        await setFriendConvertToken();
       } else {
         // ユーザーがログインしていない場合、保存されたemailとpasswordを使用してログインを試みる
         const savedEmail = await AsyncStorage.getItem("email");

--- a/frontend/src/View/Others/CheckDeviceToken.tsx
+++ b/frontend/src/View/Others/CheckDeviceToken.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect, useRef } from "react";
+import { Text, View, Button, Platform } from "react-native";
+import * as Device from "expo-device";
+import * as Notifications from "expo-notifications";
+import Constants from "expo-constants";
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: true,
+  }),
+});
+
+async function sendPushNotification(expoPushToken: string) {
+  const message = {
+    to: expoPushToken,
+    sound: "default",
+    title: "Original Title",
+    body: "And here is the body!",
+    data: { someData: "goes here" },
+  };
+
+  await fetch("https://exp.host/--/api/v2/push/send", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Accept-encoding": "gzip, deflate",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(message),
+  });
+}
+
+function handleRegistrationError(errorMessage: string) {
+  alert(errorMessage);
+  throw new Error(errorMessage);
+}
+
+async function registerForPushNotificationsAsync() {
+  if (Platform.OS === "android") {
+    Notifications.setNotificationChannelAsync("default", {
+      name: "default",
+      importance: Notifications.AndroidImportance.MAX,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: "#FF231F7C",
+    });
+  }
+
+  if (Device.isDevice) {
+    const { status: existingStatus } =
+      await Notifications.getPermissionsAsync();
+    let finalStatus = existingStatus;
+    if (existingStatus !== "granted") {
+      const { status } = await Notifications.requestPermissionsAsync();
+      finalStatus = status;
+    }
+    if (finalStatus !== "granted") {
+      handleRegistrationError(
+        "Permission not granted to get push token for push notification!"
+      );
+      return;
+    }
+    const projectId =
+      Constants?.expoConfig?.extra?.eas?.projectId ??
+      Constants?.easConfig?.projectId;
+    if (!projectId) {
+      handleRegistrationError("Project ID not found");
+    }
+    try {
+      const pushTokenString = (
+        await Notifications.getExpoPushTokenAsync({
+          projectId,
+        })
+      ).data;
+      console.log(pushTokenString);
+      return pushTokenString;
+    } catch (e: unknown) {
+      handleRegistrationError(`${e}`);
+    }
+  } else {
+    handleRegistrationError("Must use physical device for push notifications");
+  }
+}
+
+export default function CheckDeviceToken() {
+  const [expoPushToken, setExpoPushToken] = useState("");
+  const [notification, setNotification] = useState<
+    Notifications.Notification | undefined
+  >(undefined);
+  const notificationListener = useRef<Notifications.EventSubscription>();
+  const responseListener = useRef<Notifications.EventSubscription>();
+
+  useEffect(() => {
+    registerForPushNotificationsAsync()
+      .then((token) => setExpoPushToken(token ?? ""))
+      .catch((error: any) => setExpoPushToken(`${error}`));
+
+    notificationListener.current =
+      Notifications.addNotificationReceivedListener((notification) => {
+        setNotification(notification);
+      });
+
+    responseListener.current =
+      Notifications.addNotificationResponseReceivedListener((response) => {
+        console.log(response);
+      });
+
+    return () => {
+      notificationListener.current &&
+        Notifications.removeNotificationSubscription(
+          notificationListener.current
+        );
+      responseListener.current &&
+        Notifications.removeNotificationSubscription(responseListener.current);
+    };
+  }, []);
+
+  return (
+    <View
+      style={{ flex: 1, alignItems: "center", justifyContent: "space-around" }}
+    >
+      <Text>Your Expo push token: {expoPushToken}</Text>
+      <View style={{ alignItems: "center", justifyContent: "center" }}>
+        <Text>
+          Title: {notification && notification.request.content.title}{" "}
+        </Text>
+        <Text>Body: {notification && notification.request.content.body}</Text>
+        <Text>
+          Data:{" "}
+          {notification && JSON.stringify(notification.request.content.data)}
+        </Text>
+      </View>
+      <Button
+        title="Press to Send Notification"
+        onPress={async () => {
+          await sendPushNotification(expoPushToken);
+        }}
+      />
+    </View>
+  );
+}

--- a/frontend/src/component/TimeTable/FriendRegister/FriendRegisterCameraContainer.tsx
+++ b/frontend/src/component/TimeTable/FriendRegister/FriendRegisterCameraContainer.tsx
@@ -134,7 +134,6 @@ const FriendRegisterCameraContainer = () => {
             name: myDocument.userName,
             requestedAt: new Date(),
           }), // friendList に friendID を追加
-          hello: "hello",
         },
         { merge: true } // 既存のデータを保持して更新
       );
@@ -145,7 +144,6 @@ const FriendRegisterCameraContainer = () => {
       console.error("Error adding friend: ", error);
     }
   };
-  console.log(user);
 
   return (
     <FriendRegisterCamera


### PR DESCRIPTION
## 以前の仕様
フレンド登録用のトークンが、カメラ読み取り画面内にある自分のQRを表示したら初めて発行されるという仕様だった

## 問題点
一回もQRを表示せずに、ユーザー検索画面に行くと自分のトークンがundefinedとなってしまう

## 修正点
フレンド登録用のトークンの発行タイミングを初回ログイン時のHomeViewの初回コンポーネントマウント時に変更した。
また、今回の要件とは関係ないが、デバイストークンを確認できるコンポーネントを`View/Others`という場所に新たに作成した